### PR TITLE
Add products route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,12 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/lunr": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/lunr/-/lunr-2.3.2.tgz",
+      "integrity": "sha512-zcUZYquYDUEegRRPQtkZ068U9CoIjW6pJMYCVDRK25r76FEWvMm1oHqZQUfQh4ayIZ42lipXOpXEiAtGXc1XUg==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
@@ -862,6 +868,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "lunr": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg=="
     },
     "make-dir": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   "author": "van@fullstory.com",
   "license": "MIT",
   "dependencies": {
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "lunr": "^2.3.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.2",
+    "@types/lunr": "^2.3.2",
     "concurrently": "^5.1.0",
     "nodemon": "^2.0.2",
     "typescript": "^3.7.5"

--- a/public/products.json
+++ b/public/products.json
@@ -1,0 +1,134 @@
+[
+  {
+    "id": 1,
+    "title": "Bananas",
+    "description": "The old reliable.",
+    "price": 2.99,
+    "image": "banans.jpg",
+    "unit": "lb."
+  },
+  {
+    "id": 2,
+    "title": "Bluebs",
+    "description": "Extra organical and powered by blue.",
+    "price": 6.75,
+    "image": "bluebs.jpg",
+    "unit": "lb.",
+    "featured": true
+  },
+  {
+    "id": 3,
+    "title": "Carambola",
+    "description": "An all-star flavor.",
+    "price": 7.24,
+    "image": "carambola.jpg",
+    "unit": "lb."
+  },
+  {
+    "id": 4,
+    "title": "Cherries",
+    "description": "Deeply red and passionate.",
+    "price": 6.99,
+    "image": "cherries.jpg",
+    "unit": "lb."
+  },
+  {
+    "id": 5,
+    "title": "Cocktail Mix",
+    "description": "Virgin mix for adult use.",
+    "price": 15.00,
+    "image": "mixeddrink.jpg",
+    "unit": "gallon"
+  },
+  {
+    "id": 6,
+    "title": "Dragon Fruit",
+    "description": "Kissed by fire, not spicy.",
+    "price": 8.43,
+    "image": "dragonfruit.jpg",
+    "unit": "ea.",
+    "featured": true
+  },
+  {
+    "id": 7,
+    "title": "Durian",
+    "description": "Smells worse than it looks.",
+    "price": 14.99,
+    "image": "durian.jpg",
+    "unit": "ea."
+  },
+  {
+    "id": 8,
+    "title": "Grapes",
+    "description": "Use either for raisin or wine.",
+    "price": 7.24,
+    "image": "grapes.jpg",
+    "unit": "lb."
+  },
+  {
+    "id": 9,
+    "title": "Green Beans",
+    "description": "Beans, beans... great for your heart.",
+    "price": 1.79,
+    "image": "beans.jpg",
+    "unit": "lb."
+  },
+  {
+    "id": 10,
+    "title": "Mangocados",
+    "description": "Highly experimental new frewt.",
+    "price": 7.99,
+    "image": "mangocados.jpg",
+    "unit": "ea.",
+    "featured": true
+  },
+  {
+    "id": 11,
+    "title": "One Pear",
+    "description": "One lonely pear, eat while sobbing.",
+    "price": 4.99,
+    "image": "pear.jpg",
+    "unit": ""
+  },
+  {
+    "id": 12,
+    "title": "Oranges de Florida",
+    "description": "Lose the sleeves, you're in Florida.",
+    "price": 4.99,
+    "image": "oranges.jpg",
+    "unit": "lb."
+  },
+  {
+    "id": 13,
+    "title": "Peacharines",
+    "description": "This one's on us, Mother Nature.",
+    "price": 6.39,
+    "image": "peacherines.jpg",
+    "unit": "lb."
+  },
+  {
+    "id": 14,
+    "title": "Peaches",
+    "description": "The pride and joy of Georgia.",
+    "price": 4.29,
+    "image": "peaches.jpg",
+    "unit": "lb.",
+    "featured": true
+  },
+  {
+    "id": 15,
+    "title": "Pears",
+    "description": "More than one pear, pears.",
+    "price": 9.22,
+    "image": "pears.jpg",
+    "unit": "lb."
+  },
+  {
+    "id": 16,
+    "title": "Raspberries",
+    "description": "Next stop, Yumsville.",
+    "price": 5.99,
+    "image": "rasps.jpg",
+    "unit": "lb."
+  }
+]

--- a/src/controllers/ProductController.ts
+++ b/src/controllers/ProductController.ts
@@ -11,8 +11,8 @@ export function getProduct(req: Request, res: Response) {
 
   console.log(`Getting product with id ${id}`);
 
-  const controller = ProductCatalog.getInstance();
-  const product = controller.getProduct(+id);
+  const catalog = ProductCatalog.getInstance();
+  const product = catalog.getProduct(+id);
 
   // send the product or Not Found if the ID wasn't valid
   product ? res.json(product) : res.status(404).send();
@@ -29,8 +29,8 @@ export function getProducts(req: Request, res: Response) {
 
   console.log(`Getting product with query ${q}`);
 
-  const controller = ProductCatalog.getInstance();
-  const products = controller.getProducts(q);
+  const catalog = ProductCatalog.getInstance();
+  const products = catalog.getProducts(q);
 
   res.json(products);
 }

--- a/src/controllers/ProductController.ts
+++ b/src/controllers/ProductController.ts
@@ -1,0 +1,118 @@
+import { Request, Response } from 'express';
+import * as fs from 'fs';
+import * as lunr from 'lunr';
+import { Product } from '../models';
+
+export class ProductController {
+
+  private idx: lunr.Index;
+  private static instance: ProductController;
+  private products: Product[];
+
+  /**
+   * Gets a singleton instance of a ProductController.
+   */
+  static getInstance(): ProductController {
+    if (!ProductController.instance) {
+      ProductController.instance = new ProductController();
+    }
+
+    return ProductController.instance;
+  }
+
+  constructor() {
+    console.log('Initilizing products');
+
+    this.products = this.readProducts();
+
+    // randomly assign an inventory amount between 0 and 20
+    this.products.forEach(product => {
+      product.quantity = Math.floor(Math.random() * Math.floor(20))
+    });
+
+    this.idx = this.buildIndex();
+  }
+
+  /**
+   * Builds a lunr search index.
+   */
+  private buildIndex(): lunr.Index {
+    const builder = new lunr.Builder();
+    builder.ref('id');
+    builder.field('title');
+    builder.field('description');
+
+    this.products.forEach(product => builder.add(product));
+
+    return builder.build();
+  }
+
+  /**
+   * Gets a specific product.
+   * @param id Product's ID
+   */
+  getProduct(id: number): Product | undefined {
+    return this.getProducts().find(product => id === product.id)
+  }
+
+  /**
+   * Gets a list of products.
+   * @param query Optional search keyword
+   */
+  getProducts(query?: string): Product[] {
+    if (query) {
+      return this.idx.search(query).map(result => this.getProduct(+result.ref)) as Product[];
+    } else {
+      return this.products;
+    }
+  }
+
+  /**
+   * Gets the raw product data from a file.
+   * @param filename the JSON file containing product data
+   */
+  private readProducts(filename = `${__dirname}/../../public/products.json`) {
+    const content = fs.readFileSync(filename, { encoding: 'utf8' });
+
+    try {
+      return JSON.parse(content);
+    } catch (err) {
+      console.error(`Failed to convert ${filename} to JSON ${err}`);
+      return [];
+    }
+  }
+}
+
+/**
+ * Gets a product based on its ID, which is provided as a route param.
+ * @param req Express Request
+ * @param res Express Response
+ */
+export function getProduct(req: Request, res: Response) {
+  const { id } = req.params;
+
+  console.log(`Getting product with id ${id}`);
+
+  const controller = ProductController.getInstance();
+  const product = controller.getProduct(+id);
+
+  // send the product or Not Found if the ID wasn't valid
+  product ? res.json(product) : res.status(404).send();
+}
+
+/**
+ * Gets a list of products from query param for example /products?q=mangocados.
+ * If no search is specified, all products are returned.
+ * @param req Express Request
+ * @param res Express Response
+ */
+export function getProducts(req: Request, res: Response) {
+  const { q } = req.query;
+
+  console.log(`Getting product with query ${q}`);
+
+  const controller = ProductController.getInstance();
+  const products = controller.getProducts(q);
+
+  res.json(products);
+}

--- a/src/controllers/ProductController.ts
+++ b/src/controllers/ProductController.ts
@@ -1,87 +1,5 @@
 import { Request, Response } from 'express';
-import * as fs from 'fs';
-import * as lunr from 'lunr';
-import { Product } from '../models';
-
-export class ProductController {
-
-  private idx: lunr.Index;
-  private static instance: ProductController;
-  private products: Product[];
-
-  /**
-   * Gets a singleton instance of a ProductController.
-   */
-  static getInstance(): ProductController {
-    if (!ProductController.instance) {
-      ProductController.instance = new ProductController();
-    }
-
-    return ProductController.instance;
-  }
-
-  constructor() {
-    console.log('Initilizing products');
-
-    this.products = this.readProducts();
-
-    // randomly assign an inventory amount between 0 and 20
-    this.products.forEach(product => {
-      product.quantity = Math.floor(Math.random() * Math.floor(20))
-    });
-
-    this.idx = this.buildIndex();
-  }
-
-  /**
-   * Builds a lunr search index.
-   */
-  private buildIndex(): lunr.Index {
-    const builder = new lunr.Builder();
-    builder.ref('id');
-    builder.field('title');
-    builder.field('description');
-
-    this.products.forEach(product => builder.add(product));
-
-    return builder.build();
-  }
-
-  /**
-   * Gets a specific product.
-   * @param id Product's ID
-   */
-  getProduct(id: number): Product | undefined {
-    return this.getProducts().find(product => id === product.id)
-  }
-
-  /**
-   * Gets a list of products.
-   * @param query Optional search keyword
-   */
-  getProducts(query?: string): Product[] {
-    if (query) {
-      return this.idx.search(query).map(result => this.getProduct(+result.ref)) as Product[];
-    } else {
-      return this.products;
-    }
-  }
-
-  /**
-   * Gets the raw product data from a file.
-   * @param filename the JSON file containing product data
-   */
-  private readProducts(filename = `${__dirname}/../../public/products.json`) {
-    const content = fs.readFileSync(filename, { encoding: 'utf8' });
-
-    try {
-      return JSON.parse(content);
-    } catch (err) {
-      console.error(`Failed to convert ${filename} to JSON ${err}`);
-      return [];
-    }
-  }
-}
+import { ProductCatalog } from '../services';
 
 /**
  * Gets a product based on its ID, which is provided as a route param.
@@ -93,7 +11,7 @@ export function getProduct(req: Request, res: Response) {
 
   console.log(`Getting product with id ${id}`);
 
-  const controller = ProductController.getInstance();
+  const controller = ProductCatalog.getInstance();
   const product = controller.getProduct(+id);
 
   // send the product or Not Found if the ID wasn't valid
@@ -111,7 +29,7 @@ export function getProducts(req: Request, res: Response) {
 
   console.log(`Getting product with query ${q}`);
 
-  const controller = ProductController.getInstance();
+  const controller = ProductCatalog.getInstance();
   const products = controller.getProducts(q);
 
   res.json(products);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { PingController } from './controllers';
+import { getProduct, getProducts } from './controllers/ProductController';
 
 // read config
 const {
@@ -14,6 +15,8 @@ const ping = new PingController();
 
 // add controllers to routes
 app.get('/api/ping', ping.getPing);
+app.get('/api/products', getProducts);
+app.get('/api/products/:id', getProduct);
 
 // start the server
 app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));

--- a/src/models/Product.ts
+++ b/src/models/Product.ts
@@ -1,0 +1,15 @@
+/**
+ * Product models goods for sale in the e-commerce shoppe demo.
+ * A "product" could be an item in the catalog or an item in a shopping cart.
+ * This overlap exists to simplify the demo.
+ */
+export interface Product {
+  description: string;
+  featured?: boolean;    // whether or not this is a promoted product
+  id: number;
+  image: string;
+  price: number;
+  quantity: number;     // quantity could be inventory or number of items in cart
+  title: string;
+  unit: string;        // lb or kg for example
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,1 +1,2 @@
 export * from './Ping';
+export * from './Product';

--- a/src/services/ProductCatalog.ts
+++ b/src/services/ProductCatalog.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs';
+import * as lunr from 'lunr';
+import { Product } from '../models';
+
+/**
+ * ProductCatalog provides Products available to the e-commerce
+ * shoppe.
+ */
+export class ProductCatalog {
+
+  private idx: lunr.Index;
+  private static instance: ProductCatalog;
+  private products: Product[];
+
+  /**
+   * Gets a singleton instance of a ProductCatalog.
+   */
+  static getInstance(): ProductCatalog {
+    if (!ProductCatalog.instance) {
+      ProductCatalog.instance = new ProductCatalog();
+    }
+
+    return ProductCatalog.instance;
+  }
+
+  constructor() {
+    console.log('Initilizing products');
+
+    this.products = this.readProducts();
+
+    // randomly assign an inventory amount between 0 and 20
+    this.products.forEach(product => {
+      product.quantity = Math.floor(Math.random() * Math.floor(20))
+    });
+
+    this.idx = this.buildIndex();
+  }
+
+  /**
+   * Builds a lunr search index.
+   */
+  private buildIndex(): lunr.Index {
+    const builder = new lunr.Builder();
+    builder.ref('id');
+    builder.field('title');
+    builder.field('description');
+
+    this.products.forEach(product => builder.add(product));
+
+    return builder.build();
+  }
+
+  /**
+   * Gets a specific product.
+   * @param id Product's ID
+   */
+  getProduct(id: number): Product | undefined {
+    return this.getProducts().find(product => id === product.id)
+  }
+
+  /**
+   * Gets a list of products.
+   * @param query Optional search keyword
+   */
+  getProducts(query?: string): Product[] {
+    if (query) {
+      return this.idx.search(query).map(result => this.getProduct(+result.ref)) as Product[];
+    } else {
+      return this.products;
+    }
+  }
+
+  /**
+   * Gets the raw product data from a file.
+   * @param filename the JSON file containing product data
+   */
+  private readProducts(filename = `${__dirname}/../../public/products.json`) {
+    const content = fs.readFileSync(filename, { encoding: 'utf8' });
+
+    try {
+      return JSON.parse(content);
+    } catch (err) {
+      console.error(`Failed to convert ${filename} to JSON ${err}`);
+      return [];
+    }
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,1 @@
+export * from './ProductCatalog';


### PR DESCRIPTION
This PR adds a products route:
- Products are backed by a static json file in `public/data`
- There are two routes added `products` and `products/<id>`
- [Lunr](https://lunrjs.com/) provides a lightweight search service

On a design note, I moved the getProducts and getProduct middleware out of ProductController.  As I was working, it felt strange to have instance methods inside the ProductController making static calls.  I'll submit another PR to refactor the PingController and cleanup if there are no issues with this design change.