### PR TITLE
added CORS as middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,15 @@
         "@types/node": "*"
       }
     },
+    "@types/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-invOmosX0DqbpA+cE2yoHGUlF/blyf7nB0OGYBBiH27crcVm5NmFaZkLP4Ta1hGaesckCi5lVLlydNJCxkTOSg==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/express": {
       "version": "4.17.2",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
@@ -375,6 +384,15 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -1011,6 +1029,11 @@
       "requires": {
         "path-key": "^2.0.0"
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "on-finished": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   "author": "van@fullstory.com",
   "license": "MIT",
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "lunr": "^2.3.8"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.6",
     "@types/express": "^4.17.2",
     "@types/lunr": "^2.3.2",
     "concurrently": "^5.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import cors from 'cors';
 import express from 'express';
 import { PingController } from './controllers';
 import { getProduct, getProducts } from './controllers/ProductController';
@@ -9,6 +10,9 @@ const {
 
 // create and configure Express
 const app = express();
+
+// add CORS to allow local testing
+app.use(cors());
 
 // create controllers
 const ping = new PingController();


### PR DESCRIPTION
This PR add CORS support to the Express server.  This is needed because if doing local testing, your Angular/React app is running on 4200/3001 and the Express server is running on 3000.  So a browser's service call between the two will fail.